### PR TITLE
the ability to add multiple cropped versions for one image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ If no need in SEO fields, switch it off using `--no-seo`.
       has_one_attached :avatar
       has_one_attached :photo
 
-      cropped :avatar
+      cropped :avatar, version: :default, coord_attribute: :avatar_coord 
+      cropped :avatar, version: :mobile, coord_attribute: :avatar_mobile_coord
+
+      # default versions name is :default
+      # default coord_attribute attribute name is has_one_attached attribute + '_coord'
       cropped :photo
     end
   ```
@@ -68,7 +72,8 @@ If no need in SEO fields, switch it off using `--no-seo`.
   ```slim
     # admin
     # aspect_ratio default 16/9
-    = f.input :avatar, as: :cropp, input_html: { aspect_ratio: 2/3 }
+    = f.input :avatar, as: :cropp, input_html: { coord_attribute: :avatar_coord, version: :default, aspect_ratio: 16/9 }
+    = f.input :avatar, as: :cropp, input_html: { coord_attribute: :avatar_mobile_coord, version: :mobile, aspect_ratio: 2/3 }
     = f.input :photo, as: :cropp
 
     # public

--- a/app/inputs/cropp_input.rb
+++ b/app/inputs/cropp_input.rb
@@ -1,7 +1,5 @@
 class CroppInput < SimpleForm::Inputs::Base
   def input(wrapper_options = nil)
-    # binding.pry
-
     @version = input_html_options.delete(:version) || :default
     @coord_attribute = input_html_options.delete(:coord_attribute) || object.send("#{@version}_#{attribute_name}_attr_coord")
 
@@ -22,7 +20,10 @@ class CroppInput < SimpleForm::Inputs::Base
   def preview
     return unless object.send(attribute_name).attached?
     out = []
-    aspect_ratio = input_html_options.delete(:aspect_ratio) || 16/9
+
+    aspect_ratio = input_html_options.delete(:aspect_ratio) || '16/9'
+    aspect_ratio = aspect_ratio.split('/').map(&:to_f)
+    aspect_ratio = aspect_ratio[0]/aspect_ratio[1]
 
     out << %{<div class="row"><div class="col-md-8"><div class="img-container">}
 

--- a/app/inputs/cropp_input.rb
+++ b/app/inputs/cropp_input.rb
@@ -1,11 +1,16 @@
 class CroppInput < SimpleForm::Inputs::Base
   def input(wrapper_options = nil)
+    # binding.pry
+
+    @version = input_html_options.delete(:version) || :default
+    @coord_attribute = input_html_options.delete(:coord_attribute) || object.send("#{@version}_#{attribute_name}_attr_coord")
+
     out = []
     out << %{<div class="f-file">}
     out << %{  <label class="f-file__selection js-file">}
     out << %{    <span class="f-file__button">Выбрать</span>}
     out << @builder.file_field(attribute_name, input_html_options)
-    out << @builder.hidden_field(object.send("#{attribute_name}_attr_coord"))
+    out << @builder.hidden_field(@coord_attribute)
     out << %{    <span class="f-file__selected"></span>}
     out << %{  </label>}
     out << %{</div>}
@@ -18,13 +23,14 @@ class CroppInput < SimpleForm::Inputs::Base
     return unless object.send(attribute_name).attached?
     out = []
     aspect_ratio = input_html_options.delete(:aspect_ratio) || 16/9
+
     out << %{<div class="row"><div class="col-md-8"><div class="img-container">}
 
-    out << template.image_tag(object.send(attribute_name), data: { aspect_ratio: aspect_ratio, preview: ".#{attribute_name}_preview", toggle: 'cropp', coord: object.send("#{attribute_name}_attr_coord") })
+    out << template.image_tag(object.send(attribute_name), data: { aspect_ratio: aspect_ratio, preview: ".#{@version}_#{attribute_name}_preview", toggle: 'cropp', coord: @coord_attribute })
 
     out << %{</div></div><div class="col-md-4">}
     out << %{<div class="docs-preview clearfix">}
-    out << %{<div class="img-preview preview-lg #{attribute_name}_preview"></div>}
+    out << %{<div class="img-preview preview-lg #{@version}_#{attribute_name}_preview"></div>}
     out << cropped
 
     out << %{</div></div></div>}
@@ -32,12 +38,12 @@ class CroppInput < SimpleForm::Inputs::Base
   end
 
   def cropped
-    return if object.send("#{attribute_name}_attr_coord").blank?
+    return if @coord_attribute.blank?
 
     out = []
     out << %{<div class="preview-cropped"><figure class="figure">}
 
-    out << template.image_tag(object.send("#{attribute_name}_cropped"))
+    out << template.image_tag(object.send("#{@version}_#{attribute_name}_cropped"))
 
     out << %{<figcaption class="figure-caption text-center">Cropped image</figcaption></figure></div>}
     out.join

--- a/lib/adminos/helpers/models/cropped.rb
+++ b/lib/adminos/helpers/models/cropped.rb
@@ -2,18 +2,22 @@ module Adminos::Cropped
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def cropped(as_attribute, coord_attribute = nil)
+    def cropped(as_attribute, *args)
+      options = args.extract_options!
 
-      define_method "#{as_attribute}_cropped" do
-        public_send(as_attribute).variant(combine_options: { crop: public_send("#{as_attribute}_cropped_coord") })
+      version = options.delete(:version) || :default
+      coord_attribute = options.delete(:coord_attribute) || "#{as_attribute}_coord"
+
+      define_method "#{version}_#{as_attribute}_cropped" do
+        public_send(as_attribute).variant(combine_options: { crop: public_send("#{version}_#{as_attribute}_coord") })
       end
 
-      define_method "#{as_attribute}_attr_coord" do
-        coord_attribute || "#{as_attribute}_coord"
+      define_method "#{version}_#{as_attribute}_attr_coord" do
+        coord_attribute
       end
 
-      define_method "#{as_attribute}_cropped_coord" do
-        public_send(public_send("#{as_attribute}_attr_coord"))
+      define_method "#{version}_#{as_attribute}_coord" do
+        public_send(public_send("#{version}_#{as_attribute}_attr_coord"))
       end
     end
   end


### PR DESCRIPTION
## model
```ruby
  class User < ApplicationRecord
    include Adminos::Cropped
    
    has_one_attached :avatar
    has_one_attached :photo

    cropped :avatar, version: :default, coord_attribute: :avatar_coord 
    cropped :avatar, version: :mobile, coord_attribute: :avatar_mobile_coord

    # default versions name is :default
    # default coord_attribute attribute name is has_one_attached attribute + '_coord'
    cropped :photo
  end
```

## view
```
.f__fieldset
  = f.input : avatar, as: :cropp
.f__fieldset
  = f.input : avatar, as: :cropp, input_html: { coord_attribute: :cover_mobile_coord, version: :mobile, aspect_ratio: "2/3" }
```