### PR TITLE
:meta_description and :meta_title are translated if only SEO option have been used

### DIFF
--- a/lib/generators/templates/adminos/locales/model.rb.erb
+++ b/lib/generators/templates/adminos/locales/model.rb.erb
@@ -1,5 +1,5 @@
   extend Mobility
 
-  translates :name, <%= attributes.map{|a| ":#{a.name}, " if a.locale }.compact.join %><%= ':nav_name, ' if options.type == 'section' %>:meta_description, :meta_title, locale_accessors: true, ransack: true
+  translates :name, <%= attributes.map{|a| ":#{a.name}, " if a.locale }.compact.join %><%= ':nav_name, ' if options.type == 'section' %><%= ':meta_description, :meta_title, ' if options.seo? %>locale_accessors: true, ransack: true
 
   validates_with LocaleValidator


### PR DESCRIPTION
If `--no-seo` and `--locale` are used simultaneously when generating Adminos model it's not need to add to model translations of `meta_description` and  #`meta_title`.

#21 